### PR TITLE
fix: derive diagnostic option values from scores

### DIFF
--- a/src/pages/DiagnosticTestPage.tsx
+++ b/src/pages/DiagnosticTestPage.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import testData from '../../data/testData';
+import { diagnosticQuestions } from '../data/testData';
 
 const DiagnosticTestPage: React.FC = () => {
   const { t } = useTranslation();
-  const [answers, setAnswers] = useState<(string | null)[]>(Array(testData.length).fill(null));
+  const [answers, setAnswers] = useState<(number | null)[]>(Array(diagnosticQuestions.length).fill(null));
   const [submitted, setSubmitted] = useState(false);
 
-  const handleAnswerChange = (index: number, value: string) => {
+  const handleAnswerChange = (index: number, score: number) => {
     const newAnswers = [...answers];
-    newAnswers[index] = value;
+    newAnswers[index] = score;
     setAnswers(newAnswers);
   };
 
@@ -22,21 +22,21 @@ const DiagnosticTestPage: React.FC = () => {
     <div className="max-w-3xl mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">{t('diagnostic.title')}</h1>
       <form onSubmit={handleSubmit} className="space-y-6">
-        {testData.map((question, idx) => (
-          <div key={idx} className="space-y-2">
+        {diagnosticQuestions.map((question, idx) => (
+          <div key={question.id} className="space-y-2">
             <p className="font-semibold">{t(`diagnostic.questions.${question.id}`)}</p>
             <div className="flex gap-4">
               {question.options.map((option) => (
-                <label key={option.value} className="flex items-center gap-2">
+                <label key={option.score} className="flex items-center gap-2">
                   <input
                     type="radio"
                     name={`question-${idx}`}
-                    value={option.value}
-                    checked={answers[idx] === option.value}
-                    onChange={() => handleAnswerChange(idx, option.value)}
+                    value={option.score}
+                    checked={answers[idx] === option.score}
+                    onChange={() => handleAnswerChange(idx, option.score)}
                     required
                   />
-                  {t(`diagnostic.options.${option.label}`)}
+                  {t(`diagnostic.options.${option.textKey}`)}
                 </label>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- refactor DiagnosticTestPage to generate radio values from scores
- fix translation lookups to use option text keys

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892de75f8548328be851d31034a666d