### PR TITLE
refactor: relocate firebase config and guard analytics

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -3,7 +3,7 @@
 // Import only the Firebase SDKs you need
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
-import { getAnalytics } from "firebase/analytics";
+import { getAnalytics, isSupported } from "firebase/analytics";
 
 // Firebase configuration loaded from environment variables
 const firebaseConfig = {
@@ -16,11 +16,33 @@ const firebaseConfig = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
+// Ensure required Firebase configuration values are present
+const requiredFields = {
+  apiKey: firebaseConfig.apiKey,
+  authDomain: firebaseConfig.authDomain,
+  projectId: firebaseConfig.projectId,
+  appId: firebaseConfig.appId,
+};
+
+const missingFields = Object.entries(requiredFields)
+  .filter(([_, value]) => !value)
+  .map(([key]) => key);
+
+if (missingFields.length) {
+  throw new Error(`Missing Firebase configuration values: ${missingFields.join(", ")}`);
+}
+
 // Initialize Firebase app
 const app = initializeApp(firebaseConfig);
 
 // Initialize Analytics (optional)
-const analytics = getAnalytics(app);
+if (firebaseConfig.measurementId) {
+  isSupported().then(supported => {
+    if (supported) {
+      getAnalytics(app);
+    }
+  });
+}
 
 // Initialize Authentication and Google provider
 export const auth = getAuth(app);

--- a/src/pages/RegistrationPage.tsx
+++ b/src/pages/RegistrationPage.tsx
@@ -5,7 +5,7 @@ import { useUser } from '../context/UserContext';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
 
-import { auth, googleProvider } from '../../firebase';
+import { auth, googleProvider } from '../firebase';
 import { signInWithPopup } from 'firebase/auth';
 import { getRecaptchaToken } from '../../recaptcha';
 


### PR DESCRIPTION
## Summary
- move firebase config to `src` and validate required env values
- only initialize analytics when supported and measurement ID is defined
- fix firebase import path in registration page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "./context/UserContext" from "index.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_6892de70fe5c8328b5fa5427f5a032da