### PR TITLE
feat: add verification code API endpoints

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import App from './src/App';
-import { UserProvider } from './context/UserContext';
+import { UserProvider } from './src/pages/context/UserContext';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "@google/genai": "^1.10.0",
@@ -18,7 +19,9 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^15.6.0",
     "react-router-dom": "^7.7.0",
-    "recharts": "^3.1.0"
+    "recharts": "^3.1.0",
+    "express": "^4.19.2",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,92 @@
+import express from 'express';
+import nodemailer from 'nodemailer';
+
+const app = express();
+app.use(express.json());
+
+// In-memory store for verification codes
+const codes = new Map();
+
+function generateCode() {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+async function verifyRecaptcha(token) {
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+  if (!secret) {
+    console.error('Missing RECAPTCHA_SECRET_KEY');
+    return false;
+  }
+  try {
+    const response = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `secret=${secret}&response=${token}`,
+    });
+    const data = await response.json();
+    return data.success;
+  } catch (err) {
+    console.error('reCAPTCHA validation failed', err);
+    return false;
+  }
+}
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT) || 587,
+  secure: process.env.SMTP_SECURE === 'true',
+  auth: process.env.SMTP_USER
+    ? {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      }
+    : undefined,
+});
+
+app.post('/api/send-code', async (req, res) => {
+  const { email, recaptchaToken } = req.body || {};
+  if (!email || !recaptchaToken) {
+    return res.status(400).json({ error: 'Missing email or reCAPTCHA token' });
+  }
+  const valid = await verifyRecaptcha(recaptchaToken);
+  if (!valid) {
+    return res.status(400).json({ error: 'Invalid reCAPTCHA token' });
+  }
+  const code = generateCode();
+  codes.set(email, { code, expires: Date.now() + 10 * 60 * 1000 });
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to: email,
+      subject: 'Código de verificación',
+      text: `Tu código de verificación es ${code}`,
+    });
+    res.json({ message: 'Verification code sent' });
+  } catch (err) {
+    console.error('Error sending email', err);
+    res.status(500).json({ error: 'Failed to send verification email' });
+  }
+});
+
+app.post('/api/verify-code', async (req, res) => {
+  const { email, code, recaptchaToken } = req.body || {};
+  if (!email || !code || !recaptchaToken) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const valid = await verifyRecaptcha(recaptchaToken);
+  if (!valid) {
+    return res.status(400).json({ error: 'Invalid reCAPTCHA token' });
+  }
+  const record = codes.get(email);
+  if (!record || record.code !== code || Date.now() > record.expires) {
+    return res.status(400).json({ error: 'Invalid or expired code' });
+  }
+  codes.delete(email);
+  res.json({ fullName: 'Usuario', email });
+});
+
+const PORT = process.env.API_PORT || 5001;
+app.listen(PORT, () => {
+  console.log(`API server listening on port ${PORT}`);
+});
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig(({ mode }) => {
     server: {
       port: Number(env.VITE_PORT) || 3000,
       strictPort: true,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL || 'http://localhost:5001',
+          changeOrigin: true,
+        }
+      }
     },
 
     // Alias de importaciones para rutas más limpias


### PR DESCRIPTION
## Summary
- add Express server with `/api/send-code` and `/api/verify-code`
- proxy API requests from Vite dev server
- wire up UserContext import and add server script

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "./pages/DiagnosticTestPage" from "src/App.tsx")*


------
https://chatgpt.com/codex/tasks/task_e_688f2b5bbe688328b943c5a536cb82d9