### PR TITLE
Ensure registration route is default and add wildcard redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import RegistrationPage from './pages/RegistrationPage';
 import DashboardPage from './pages/DashboardPage';
@@ -23,8 +23,8 @@ function App(): React.ReactNode {
   return (
     <Routes>
       {/* Public routes */}
-      <Route element={<AuthLayout />}> 
-        <Route path="/" element={<RegistrationPage />} />
+      <Route element={<AuthLayout />}>
+        <Route index element={<RegistrationPage />} />
       </Route>
 
       {/* Private routes */}
@@ -38,6 +38,8 @@ function App(): React.ReactNode {
         <Route path="/journal" element={<EmotionalJournalPage />} />
         <Route path="/wisdom-drops" element={<WisdomDropsPage />} />
       </Route>
+
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- switch registration to index route under `AuthLayout`
- redirect unknown paths to registration with wildcard route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "./context/UserContext" from "index.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_688f27a2d71083288316b3120d5c702d