### PR TITLE
Use BrowserRouter for routing

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2,7 +2,7 @@
 import i18n from './i18n';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { HashRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import App from './src/App';
 import { UserProvider } from './context/UserContext';
@@ -16,11 +16,11 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <I18nextProvider i18n={i18n}>
-      <HashRouter>
+      <BrowserRouter>
         <UserProvider>
           <App />
         </UserProvider>
-      </HashRouter>
+      </BrowserRouter>
     </I18nextProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace `HashRouter` with `BrowserRouter` in the main entry to support standard routing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893bd8e52c48328aef0bc7f8c5644d8